### PR TITLE
fixed approve error by reversing swap

### DIFF
--- a/contracts/SwapExamples.sol
+++ b/contracts/SwapExamples.sol
@@ -31,8 +31,8 @@ contract SwapExamples {
     /// @notice swapExactInputSingle swaps a fixed amount of DAI for a maximum possible amount of WETH9
     /// using the DAI/WETH9 0.3% pool by calling `exactInputSingle` in the swap router.
     /// @dev The calling address must approve this contract to spend at least `amountIn` worth of its DAI for this function to succeed.
-    /// @param amountIn The exact amount of DAI that will be swapped for WETH9.
-    /// @return amountOut The amount of WETH9 received.
+    /// @param amountIn The exact amount of WETH9 that will be swapped for DAI.
+    /// @return amountOut The amount of DAI received.
     function swapExactInputSingle(uint256 amountIn)
         public
         returns (uint256 amountOut)
@@ -42,21 +42,21 @@ contract SwapExamples {
 
         // Transfer the specified amount of DAI to this contract.
         TransferHelper.safeTransferFrom(
-            DAI,
+            WETH9,
             msg.sender,
             address(this),
             amountIn
         );
 
-        // Approve the router to spend DAI.
-        TransferHelper.safeApprove(DAI, address(swapRouter), amountIn);
+        // Approve the router to spend WETH9.
+        TransferHelper.safeApprove(WETH9, address(swapRouter), amountIn);
 
         // Naively set amountOutMinimum to 0. In production, use an oracle or other data source to choose a safer value for amountOutMinimum.
         // We also set the sqrtPriceLimitx96 to be 0 to ensure we swap our exact input amount.
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
             .ExactInputSingleParams({
-                tokenIn: DAI,
-                tokenOut: WETH9,
+                tokenIn: WETH9,
+                tokenOut: DAI,
                 fee: poolFee,
                 recipient: msg.sender,
                 deadline: block.timestamp,
@@ -69,32 +69,32 @@ contract SwapExamples {
         amountOut = swapRouter.exactInputSingle(params);
     }
 
-    /// @notice swapExactOutputSingle swaps a minimum possible amount of DAI for a fixed amount of WETH.
-    /// @dev The calling address must approve this contract to spend its DAI for this function to succeed. As the amount of input DAI is variable,
+    /// @notice swapExactOutputSingle swaps a minimum possible amount of WETH9 for a fixed amount of DAI.
+    /// @dev The calling address must approve this contract to spend its WETH9 for this function to succeed. As the amount of input DAI is variable,
     /// the calling address will need to approve for a slightly higher amount, anticipating some variance.
-    /// @param amountOut The exact amount of WETH9 to receive from the swap.
-    /// @param amountInMaximum The amount of DAI we are willing to spend to receive the specified amount of WETH9.
-    /// @return amountIn The amount of DAI actually spent in the swap.
+    /// @param amountOut The exact amount of DAI to receive from the swap.
+    /// @param amountInMaximum The amount of WETH9 we are willing to spend to receive the specified amount of DAI.
+    /// @return amountIn The amount of WETH9 actually spent in the swap.
     function swapExactOutputSingle(uint256 amountOut, uint256 amountInMaximum)
         public
         returns (uint256 amountIn)
     {
-        // Transfer the specified amount of DAI to this contract.
+        // Transfer the specified amount of WETH9 to this contract.
         TransferHelper.safeTransferFrom(
-            DAI,
+            WETH9,
             msg.sender,
             address(this),
             amountInMaximum
         );
 
-        // Approve the router to spend the specifed `amountInMaximum` of DAI.
+        // Approve the router to spend the specifed `amountInMaximum` of WETH9.
         // In production, you should choose the maximum amount to spend based on oracles or other data sources to acheive a better swap.
-        TransferHelper.safeApprove(DAI, address(swapRouter), amountInMaximum);
+        TransferHelper.safeApprove(WETH9, address(swapRouter), amountInMaximum);
 
         ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter
             .ExactOutputSingleParams({
-                tokenIn: DAI,
-                tokenOut: WETH9,
+                tokenIn: WETH9,
+                tokenOut: DAI,
                 fee: poolFee,
                 recipient: msg.sender,
                 deadline: block.timestamp,
@@ -109,9 +109,9 @@ contract SwapExamples {
         // For exact output swaps, the amountInMaximum may not have all been spent.
         // If the actual amount spent (amountIn) is less than the specified maximum amount, we must refund the msg.sender and approve the swapRouter to spend 0.
         if (amountIn < amountInMaximum) {
-            TransferHelper.safeApprove(DAI, address(swapRouter), 0);
+            TransferHelper.safeApprove(WETH9, address(swapRouter), 0);
             TransferHelper.safeTransfer(
-                DAI,
+                WETH9,
                 msg.sender,
                 amountInMaximum - amountIn
             );

--- a/scripts/deploy_uniswap_singleswap.py
+++ b/scripts/deploy_uniswap_singleswap.py
@@ -21,8 +21,8 @@ def deploy_uniswap_singleswap():
 
 def main():
     account = accounts[0]
-    # WETH address
-    erc20_address = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+    # erc20_address = '0x6B175474E89094C44Da98b954EedeAC495271d0F' # DAI address
+    erc20_address = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' # WETH address
     amount = Web3.toWei(0.1, "ether")
     print("Getting WETH...")
     get_weth(account)


### PR DESCRIPTION
I reversed the swap from DAI in - WETH out to WETH in - DAI out. I tried approving DAI to be transferred from my account to the contract but I realized I may have been approving WETH from my account because that is what was approved in the code that I copypastad. Can't transfer DAI from my account when I'm approving WETH to be transferred out. 